### PR TITLE
Use standard x509

### DIFF
--- a/convert_from_tlsa.go
+++ b/convert_from_tlsa.go
@@ -19,6 +19,7 @@
 package safetlsa
 
 import (
+	"crypto/x509"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -26,7 +27,6 @@ import (
 	"github.com/miekg/dns"
 
 	"github.com/namecoin/ncdns/certdehydrate"
-	"github.com/namecoin/x509-signature-splice/x509"
 )
 
 func GetCertFromTLSA(domain string, tlsa *dns.TLSA, parentDERBytes []byte, parentPrivateKey interface{}) ([]byte, error) {


### PR DESCRIPTION
We can do this since `certdehydrate` uses `SpliceSigner` now.